### PR TITLE
Limit input and output range based on bit count

### DIFF
--- a/src/gui/inputs_outputs.rs
+++ b/src/gui/inputs_outputs.rs
@@ -1,5 +1,6 @@
 use crate::simulator::ir::Value;
 use core::fmt;
+use core::ops::RangeInclusive;
 use eframe::egui;
 
 /// List of circuit inputs & outputs, each with a numeric input to change it.
@@ -10,7 +11,7 @@ impl InputsOutputs {
 	pub fn show(
 		&mut self,
 		ctx: &egui::CtxRef,
-		inputs: &[(impl fmt::Display, usize)],
+		inputs: &[(impl fmt::Display, RangeInclusive<i64>, usize)],
 		outputs: &[(impl fmt::Display, usize)],
 		input_values: &mut [Value],
 		output_values: &[Value],
@@ -26,13 +27,13 @@ impl InputsOutputs {
 					ui.horizontal(|ui| {
 						if !inputs.is_empty() {
 							ui.vertical(|ui| {
-								for (l, i) in inputs.iter() {
+								for (l, r, i) in inputs.iter() {
 									ui.horizontal(|ui| {
 										let mut v = match input_values[*i] {
 											Value::Set(v) => v,
 											_ => todo!(),
 										};
-										ui.add(egui::DragValue::new(&mut v));
+										ui.add(egui::DragValue::new(&mut v).clamp_range(r.clone()));
 										input_values[*i] = Value::Set(v);
 										ui.label(l);
 									});

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -334,7 +334,9 @@ impl epi::App for App {
 		let (mut ei, mut eo) = (Vec::new(), Vec::new());
 		for (c, ..) in self.circuit.components(circuit::Aabb::ALL) {
 			if let Some(i) = c.external_input() {
-				ei.push((c.label().unwrap_or_default(), i));
+				let bits = c.outputs()[0].bits.get();
+				let range = 0..=((1 << bits) - 1);
+				ei.push((c.label().unwrap_or_default(), range, i));
 			}
 			if let Some(o) = c.external_output() {
 				eo.push((c.label().unwrap_or_default(), o));

--- a/src/simulator/base/mod.rs
+++ b/src/simulator/base/mod.rs
@@ -204,7 +204,7 @@ impl Component for In {
 	}
 
 	fn outputs(&self) -> Box<[OutputType]> {
-		[OutputType { bits: NonZeroU8::new(32).unwrap() }].into()
+		[OutputType { bits: self.bits }].into()
 	}
 
 	fn generate_ir(&self, _: GenerateIr) -> usize {
@@ -258,7 +258,7 @@ impl Component for Out {
 	}
 
 	fn inputs(&self) -> Box<[InputType]> {
-		[InputType { bits: NonZeroU8::new(32).unwrap() }].into()
+		[InputType { bits: self.bits }].into()
 	}
 
 	fn outputs(&self) -> Box<[OutputType]> {


### PR DESCRIPTION
Limits the range of possible input values to `[0, (2^n)-1]` where `n` is the bit width of the input. This only changes the behavior of the "Inputs & Outputs" gui dialog.

### Screenshots

Previous behavior (allows any value, but applies a mask):
![before](https://user-images.githubusercontent.com/41806047/143685903-9071f689-b860-434b-b1df-8928b98d5767.gif)

Modified behavior (limits the range, but the value is still masked):
![after](https://user-images.githubusercontent.com/41806047/143685905-85eb44da-4f41-4298-9317-2a0a9b39b800.gif)

### Notes

- If the value is guaranteed to never go out of range, applying a mask becomes redundant.
- This range is meant to limit the possible _bit sequences_ rather than _values_. E.g., say we have a 5 bit input. The allowed range then becomes `0..=31`. This corresponds to all possible bit sequences of this input: `00000`, ..., `11111`. These bit sequences can, however, represent many different numerical ranges (or non at all), based on what encoding is used. (`[0, 31]` as unsigned integer, but `[-16, 15]` in two's complement)
  So in order to account for this in the future, it might be necessary to modify the range before setting it on the gui element.
