### PR TITLE
Simulator debugging + fix redundant program generation

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -100,6 +100,7 @@ pub struct App {
 	circuit_offset: egui::Vec2,
 
 	enable_simulation: bool,
+	debug_simulation: bool,
 }
 
 impl App {
@@ -133,6 +134,7 @@ impl App {
 			circuit_offset: Default::default(),
 
 			enable_simulation: true,
+			debug_simulation: false,
 		};
 		if let Some(f) = std::env::args().skip(1).next() {
 			let f = PathBuf::from(f);
@@ -349,6 +351,7 @@ impl epi::App for App {
 				menu::menu(ui, "Simulation", |ui| {
 					ui.checkbox(&mut self.enable_simulation, "Enabled");
 					step_simulation |= ui.button("Step").clicked();
+					ui.checkbox(&mut self.debug_simulation, "Debug simulation");
 				});
 			});
 		});
@@ -727,6 +730,17 @@ impl epi::App for App {
 					if e.drag_started() && e.dragged_by(PointerButton::Primary) {
 						let (_, p, d) = self.circuit.component(c).unwrap();
 						self.drag_component = Some((c, (p - point).unwrap(), d));
+					}
+				}
+			}
+
+			// Mark any components that will be updated in the next step
+			if self.debug_simulation {
+				let list = self.program_state.dirty_components().collect::<Vec<_>>();
+				for (c, p, _, h) in self.circuit.components(aabb) {
+					if list.contains(&h) {
+						dbg!(c.name());
+						paint.circle_filled(point2pos(p), 4.0, Color32::RED);
 					}
 				}
 			}

--- a/src/simulator/graph.rs
+++ b/src/simulator/graph.rs
@@ -275,6 +275,7 @@ where
 		let mut input_map = Vec::new();
 		let mut output_map = Vec::new();
 		let mut ir = Vec::new();
+		let mut node_to_graph_map = Vec::new();
 		for (h, Node { inputs, outputs, component, .. }) in self.nodes.iter() {
 			let inp = inputs
 				.iter()
@@ -301,7 +302,10 @@ where
 			let gen = GenerateIr {
 				inputs: &inp,
 				outputs: &outp,
-				out: &mut |ops| ir.push((h, ops)),
+				out: &mut |ops| {
+					node_to_graph_map.push(GraphNodeHandle(h));
+					ir.push((h, ops));
+				},
 				memory_size,
 				nodes,
 			};
@@ -363,6 +367,7 @@ where
 			output_map: output_map.into(),
 			input_nodes_map: input_nodes_map.into(),
 			nodes,
+			node_to_graph_map: node_to_graph_map.into(),
 		}
 	}
 

--- a/src/simulator/ir/program.rs
+++ b/src/simulator/ir/program.rs
@@ -1,4 +1,4 @@
-use super::super::NexusHandle;
+use super::super::{GraphNodeHandle, NexusHandle};
 use crate::integer_set::IntegerSet;
 use core::{fmt, mem};
 use std::sync::Arc;
@@ -22,6 +22,8 @@ pub struct Program {
 	pub(crate) output_map: Box<[(usize, usize)]>,
 	/// Input to node map.
 	pub(crate) input_nodes_map: Box<[Box<[usize]>]>,
+	/// Node to graph handle map
+	pub(crate) node_to_graph_map: Box<[GraphNodeHandle]>,
 }
 
 #[derive(Debug, Default)]
@@ -145,6 +147,13 @@ impl State {
 			}
 		}
 		self.update_dirty.len()
+	}
+
+	/// Return a list of all dirty components
+	pub fn dirty_components<'a>(&'a self) -> impl Iterator<Item = GraphNodeHandle> + 'a {
+		self.update_dirty
+			.iter()
+			.map(|i| self.program.node_to_graph_map[*i])
 	}
 }
 


### PR DESCRIPTION
- When enabling simulator debugging, dirtied components are marked with a red dot.
- The program was being regenerated even if the circuit did not change. An extra check to prevent this has been added.